### PR TITLE
Update build.gradle Fixing Issue with Flurry

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,5 +37,5 @@ repositories {
 
 dependencies {
   compile 'com.facebook.react:react-native:+'
-  compile 'com.flurry.android:analytics:+@aar'
+  compile 'com.flurry.android:analytics:7.0.0@aar'
 }


### PR DESCRIPTION
Currently the dependencies for 'com.flurry.android.analytics:+@arr' is not working, so now it is working with the 7.0.0 version.