### PR TITLE
bugfix: update complie api to implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,6 @@ repositories {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:+'
-  compile 'com.flurry.android:analytics:7.0.0@aar'
+  implementation 'com.facebook.react:react-native:+'
+  implementation 'com.flurry.android:analytics:7.0.0@aar'
 }


### PR DESCRIPTION
Updated complie api to implementation to fix `Could not find method compile() for arguments [com.facebook.react:react-native:+] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.`